### PR TITLE
fix: properties input fiels sync with remote

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -63,7 +63,7 @@ export default class YorkiePlugin extends Plugin {
 		this.registerEditorExtension(EditorView.updateListener.of((viewUpdate) => {
 			if (viewUpdate.docChanged) {
 				for (const tx of viewUpdate.transactions) {
-					const events = ['input', 'delete', 'move', 'undo', 'redo'];
+					const events = ['input', 'delete', 'move', 'undo', 'redo', 'set'];
 					if (!events.map((event) => tx.isUserEvent(event)).some(Boolean)) {
 						continue;
 					}

--- a/main.ts
+++ b/main.ts
@@ -14,6 +14,8 @@ import {
 } from "./events/createOrEnterDocumentKeyEvent";
 
 
+const USER_EVENTS_LIST = ['input', 'delete', 'move', 'undo', 'redo', 'set'];
+
 export default class YorkiePlugin extends Plugin {
 	basePath = (this.app.vault.adapter as any).basePath
 
@@ -62,8 +64,7 @@ export default class YorkiePlugin extends Plugin {
 		this.registerEditorExtension(EditorView.updateListener.of((viewUpdate) => {
 			if (viewUpdate.docChanged) {
 				for (const tx of viewUpdate.transactions) {
-					const events = ['input', 'delete', 'move', 'undo', 'redo', 'set'];
-					if (!events.map((event) => tx.isUserEvent(event)).some(Boolean)) {
+					if (!USER_EVENTS_LIST.map((event) => tx.isUserEvent(event)).some(Boolean)) {
 						continue;
 					}
 					if (tx.annotation(Transaction.remote)) {

--- a/main.ts
+++ b/main.ts
@@ -12,7 +12,6 @@ import {
 	CREATE_OR_ENTER_DOCUMENT_KEY_EVENT,
 	CreateOrEnterDocumentKeyEventDto
 } from "./events/createOrEnterDocumentKeyEvent";
-import CodeMirror from "codemirror";
 
 
 export default class YorkiePlugin extends Plugin {


### PR DESCRIPTION
in codemirror properties input's event name is 'set'
so, add 'set' allowed events list

---
resolve #9 